### PR TITLE
feat: reactivate ECR registry lifecycle rules

### DIFF
--- a/roles/build_push_docker_image/files/cf-ecr.yml
+++ b/roles/build_push_docker_image/files/cf-ecr.yml
@@ -10,55 +10,38 @@ Resources:
     Type: AWS::ECR::Repository
     Properties:
       RepositoryName: '{{ ecr_repository_name }}'
-# NOTE-zw[20230720]: even with the simple rules below, the cleanup logic is not appropriately executed. We have one
-# repository ended us with 18 untagged images and 3 tagged images (was 33 untagged + 17 tagged). It is too risky to
-# keep using this feature. We will disable it for now and create a separate lambda function to do the cleanup works.
-#      LifecyclePolicy:
-#        # NOTE-zw:
-#        # (I) the lovely AWS makes inconsistency between such a short distance. Here the `LifecyclePolicyText`
-#        # is literally a text (of type String), while several lines down there, the `RepositoryPolicyText` is a
-#        # JsonObject, therefore we could use the YAML representation...
-#        # (II) we do not need to keep all tagged images forever, but to specify the amount of tagged images to keep,
-#        # we have to set `tagStatus` to `tagged`. This makes another property `tagPrefixList` mandatory. And the
-#        # `tagPrefixList` does not accept wildcard or empty value...the policies are applied sequentially one by one
-#        # and no way to combine them with logical expression...even weird, tagStatus==untagged can only be used once.
-#        # So our workaround is to make the policies for the
-#        # logic (order by priority, policy with smaller number will be applied earlier):
-#        #   1. keep only 10 fresh but untagged images
-#        #   2. for all images (irrelevant from the tagging status), we keep only 20 in total
-#        # Therefore, at anytime, we may have 0~10 untagged images, and 0~20 tagged images. A gaussian random simulation
-#        # of 10E4 times, 92% cases we ended up at 10:10 untagged:tagged images.
-#        # (III) at AWS, a junior secondary receptionist summer internship trainee is allowed to develop features and
-#        # ship to production without code review
-#        LifecyclePolicyText: |
-#          {
-#            "rules": [
-#              {
-#                "rulePriority": 1,
-#                "description": "Keep only 10 most recent untagged images",
-#                "selection": {
-#                  "tagStatus": "untagged",
-#                  "countType": "imageCountMoreThan",
-#                  "countNumber": 10
-#                },
-#                "action": {
-#                  "type": "expire"
-#                }
-#              },
-#              {
-#                "rulePriority": 50,
-#                "description": "Keep only 20 images in total",
-#                "selection": {
-#                  "tagStatus": "any",
-#                  "countType": "imageCountMoreThan",
-#                  "countNumber": 20
-#                },
-#                "action": {
-#                  "type": "expire"
-#                }
-#              }
-#            ]
-#          }
+      # NOTE-zw: the lovely AWS makes inconsistency between such a short distance. Here the `LifecyclePolicyText`
+      # is literally a text (of type String), while several lines down there, the `RepositoryPolicyText` is a
+      # JsonObject, therefore we could use the YAML representation...
+      LifecyclePolicyText: |
+        {
+          "rules": [{
+            "rulePriority": 10,
+            "description": "Keep 10 most recent tagged images",
+            "selection": {
+              "tagStatus": "tagged",
+              "tagPatternList": ["*"],
+              "countType": "imageCountMoreThan",
+              "countNumber": 10
+            },
+            "action": {
+              "type": "expire"
+            }
+          },
+          {
+            "rulePriority": 100,
+            "description": "Expire old untagged images after four weeks",
+            "selection": {
+              "tagStatus": "untagged",
+              "countType": "sinceImagePushed",
+              "countNumber": 28,
+              "countUnit": "days"
+            },
+            "action": {
+              "type": "expire"
+            }
+          }]
+        }
 #{% if share_with_org_unit is defined and share_with_org_unit != '' %}
 #
       RepositoryPolicyText:


### PR DESCRIPTION
To keep:
* 10 tagged images
* 28 days of untagged images
...and retire anything else.